### PR TITLE
errors are printed in stdout, so manually append them to error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,9 @@ SambaClient.prototype.execute = function(cmd, cmdArgs, workingDir, cb) {
   };
 
   exec(command, options, function(err, stdout, stderr) {
+    if(err !== null) {
+      err.message += stdout;
+    }
     var allOutput = (stdout + stderr);
     cb(err, allOutput);
   });

--- a/index.js
+++ b/index.js
@@ -103,10 +103,10 @@ SambaClient.prototype.execute = function(cmd, cmdArgs, workingDir, cb) {
   };
 
   exec(command, options, function(err, stdout, stderr) {
-    if(err !== null) {
-      err.message += stdout;
-    }
     var allOutput = (stdout + stderr);
+    if(err !== null) {
+      err.message += allOutput;
+    }
     cb(err, allOutput);
   });
 };


### PR DESCRIPTION
so an exception handler can see it