### PR TITLE
Update prerequisite info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Node.js wrapper for smbclient
 
 Requirements
 ------------
-Smbclient must be installed. This can be installed on OSX with `brew install homebrew/boneyard/samba` and on Ubuntu with `sudo apt-get install smbclient`.
+Smbclient must be installed. This can be installed on OSX with Homebrew [using this script](https://raw.githubusercontent.com/Homebrew/homebrew-core/1fd22fea2426e1ae34e85177234c6e59f63add58/Formula/samba.rb) and on Ubuntu with `sudo apt-get install smbclient`.
 
 API
 -------------


### PR DESCRIPTION
`homebrew/boneyard` was emptied out a while ago; install instructions referencing that tap no longer function. This script was given to me by @jakesjews, and it worked well for me.