### PR TITLE
Make it compatible with Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,17 @@ await client.sendFile('somePath/file', 'destinationFolder/name');
 
 // get a file
 await client.getFile('someRemotePath/file', 'destinationFolder/name');
+
+// create a folder
+await client.mkdir('folder/tree', (optional) 'current/working/directory');
+// By default CWD is __dirname
+
+// executes dir command in remote directory
+await client.dir('remote/folder', (optional) 'current/working/directory');
+// By default CWD is __dirname
 ```
+
+Troubleshooting 
+-------------
+### Error: spawn ENOTDIR in Electron
+Pass an empty string in the Current Working Directory parameter, for more information see [this PR](https://github.com/eflexsystems/node-samba-client/pull/20).

--- a/index.js
+++ b/index.js
@@ -58,12 +58,12 @@ class SambaClient {
     }
   }
 
-  mkdir(remotePath) {
-    return this.execute('mkdir', remotePath.replace(singleSlash, '\\'), '');
+  mkdir(remotePath, cwd) {
+    return this.execute('mkdir', remotePath.replace(singleSlash, '\\'), cwd !== null && cwd !== undefined ? cwd : __dirname);
   }
 
-  dir(remotePath) {
-    return this.execute('dir', remotePath.replace(singleSlash, '\\'), '');
+  dir(remotePath, cwd) {
+    return this.execute('dir', remotePath.replace(singleSlash, '\\'), cwd !== null && cwd !== undefined ? cwd : __dirname);
   }
 
   async fileExists(remotePath) {

--- a/index.js
+++ b/index.js
@@ -59,11 +59,11 @@ class SambaClient {
   }
 
   mkdir(remotePath) {
-    return this.execute('mkdir', remotePath.replace(singleSlash, '\\'), __dirname);
+    return this.execute('mkdir', remotePath.replace(singleSlash, '\\'), '');
   }
 
   dir(remotePath) {
-    return this.execute('dir', remotePath.replace(singleSlash, '\\'), __dirname);
+    return this.execute('dir', remotePath.replace(singleSlash, '\\'), '');
   }
 
   async fileExists(remotePath) {


### PR DESCRIPTION
The variable `__dirname` when running in electron is `/home/koraniar/GitHub/leopardcreek-app/dist_electron/linux-unpacked/resources/app.asar` and `app.asar` is a file not a directory.

So the actions `dir` and `mkdir` fails with the error **Error: spawn ENOTDIR**.

Closes #19 