### PR TITLE
Pass CWD as parameter to fileExists

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ await client.mkdir('folder/tree', (optional) 'current/working/directory');
 // executes dir command in remote directory
 await client.dir('remote/folder', (optional) 'current/working/directory');
 // By default CWD is __dirname
+
+// validate if file or folder exists in the remote device
+await client.fileExists('remote/file', (optional) 'current/working/directory');
+// By default CWD is __dirname
 ```
 
 Troubleshooting 

--- a/index.js
+++ b/index.js
@@ -66,9 +66,9 @@ class SambaClient {
     return this.execute('dir', remotePath.replace(singleSlash, '\\'), cwd !== null && cwd !== undefined ? cwd : __dirname);
   }
 
-  async fileExists(remotePath) {
+  async fileExists(remotePath, cwd) {
     try {
-      await this.dir(remotePath);
+      await this.dir(remotePath, cwd);
       return true;
     } catch(e) {
       if (e.message.match(missingFileRegex)) {


### PR DESCRIPTION
The `fileExists` function is affected by the changes made in my last PR #20 because it internally uses `dir`.
I didn't see it, sorry about that.