### PR TITLE
Enable use of --max-protocol option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ build/Release
 node_modules
 
 *.swp
+
+# JetBrains IDEs including IDEA and WebStorm
+.idea/*

--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ class SambaClient {
     this.username = wrap(options.username || 'guest');
     this.password = options.password ? wrap(options.password) : null;
     this.domain = options.domain;
+    // Possible values for protocol version are listed in the Samba man pages:
+    // https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#CLIENTMAXPROTOCOL
+    this.maxProtocol = options.maxProtocol;
   }
 
   getFile(path, destination) {
@@ -95,6 +98,10 @@ class SambaClient {
     if (this.domain) {
       args.push('-W');
       args.push(this.domain);
+    }
+
+    if (this.maxProtocol) {
+      args.push('--max-protocol', this.maxProtocol);
     }
 
     return args;


### PR DESCRIPTION
Some library clients may need to specify this in order to work around buggy behaviour between smbclient and difficult servers.

Fixes #22 