### PR TITLE
Add cwd() function

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,15 @@ class SambaClient {
     }
   }
 
+  async cwd(){
+    try{
+      const cd = await this.execute('cd','','');
+      return cd.match(/\s.{2}\s(.+?)/)[1];
+    }catch(e){
+      throw e;
+    }
+  }
+
   getSmbClientArgs(fullCmd) {
     let args = ['-U', this.username];
 


### PR DESCRIPTION
## What?
Return a string of what the server believes is the current remote working directory.

## Why?
Issue #26.

## How?
Invokes the _execute_ method with a "cd" argument. This effectively retrieves the current working directory on the server.

That is, the following string is returned:
Current directory is **\<current remote working directory\>**
 
Regex is utilized on said string in order to capture the **current remote working directory** which is then returned.