### PR TITLE
Add cwd() and list() functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,33 @@ class SambaClient {
       }
     }
   }
+  
+  async cwd(){
+    try{
+      const cd = await this.execute('cd','','');
+      return cd.match(/\s.{2}\s(.+?)/)[1];
+    }catch(e){
+      throw e;
+    }
+  }
 
+  async list(remotePath){
+    const remoteDirList = [];
+    try{
+      const remoteDirContents = await this.dir(remotePath);
+      for(const content of remoteDirContents.matchAll(/\s?(.+)\s{2}/g)){
+        remoteDirList.push({
+          name: content[1].match(/\s?(.*?)\s/)[1],
+          type: content[1].match(/(.)\s+[0-9]/)[1],
+          size: content[1].match(/.\s+([0-9]+)/)[1],
+          modifyTime: content[1].match(/[0-9]+\s+(.+)/)[1]
+        });
+      }
+      return remoteDirList;
+    }catch(e){
+      throw e;
+    }
+  }
   getSmbClientArgs(fullCmd) {
     let args = ['-U', this.username];
 


### PR DESCRIPTION
## What?
cwd() - Returns a string of what the server believes is the current remote working directory.
list(**remotePath**) - Takes a user provided string **remotePath** which returns an array of objects representing items in the remote directory.

## Why?
Issue #26.

## How?
cwd() - Invokes the _execute_ method with a "cd" argument. This effectively retrieves the current working directory on the server.

That is, the following string is returned:
Current directory is **\<current remote working directory\>**

Regex is utilized on said string in order to capture the **current remote working directory** which is then returned.

___

list(**remotePath**) - Invokes the _dir_ method with a user's **remotePath** string argument. This effectively retrieves a list of files and folders from the server's **remotePath** directory.

That is, something to the effect of the following is returned:
![dir](https://user-images.githubusercontent.com/43649338/100636746-a31f9900-32f7-11eb-8e9b-3a8e7d2787e3.png)

Regex is utilized on said output in order to capture an iterator of the contents of the remote directory. This captured iterator is then iterated through in which further regexes are applied in order to formulate an object with the following properties:

{
    name: // file name
    type: // file type
    size: // file size
    modifyTime: // file timestamp of modified time
}

Each object is pushed to an array which is then returned.