### PR TITLE
add option to mask command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ let client = new SambaClient({
   address: '//server/folder', // required
   username: 'test', // not required, defaults to guest
   password: 'test', // not required
-  domain: 'WORKGROUP' // not required
-  maxProtocol: 'SMB3' // not required
+  domain: 'WORKGROUP', // not required
+  maxProtocol: 'SMB3', // not required
+  maskCmd: true, // not required, defaults to false
 });
 
 // send a file


### PR DESCRIPTION
Hi,

This pull request adds an option in the samba-client constructor to mask command by passing `maskCmd: true`. 
This flag defaults to `false` in order to not disturb any existing functionality.

I've tested it with a few error cases. Differences are shown below:

```
OS: Debian GNU/Linux 9 (stretch)
smbclient: Version 4.5.16-Debian
```

(1): Incorrect Network name:
`maskCmd: false`
```
Error: Command failed: smbclient -U 'some-username' -c 'dir ' //10.10.0.2/bad-dir-path '<some_password>' --max-protocol SMB3↵Domain=[...] OS=[] Server=[]↵tree connect failed: NT_STATUS_BAD_NETWORK_NAME↵Domain=[...] OS=[] Server=[]↵
```


`maskCmd: true`
```
Error: tree connect failed: NT_STATUS_BAD_NETWORK_NAME↵Domain=[...] OS=[] Server=[]↵
```


(2): Incorrect credentials
`maskCmd: false`
```
Error: Command failed: smbclient -U 'some-username' -c 'dir ' //10.10.0.2/test '<some_password>' --max-protocol SMB3↵session setup failed: NT_STATUS_LOGON_FAILURE↵
```

`maskCmd: true`
```
Error: session setup failed: NT_STATUS_LOGON_FAILURE↵
```

(3): smbclient not installed
`maskCmd: false`
```
Error: Command failed: smbclient -U 'Guest' -N -c 'mkdir test-directory' 
/bin/sh: smbclient: command not found
/bin/sh: smbclient: command not found
```

`maskCmd: true`
```
Error: /bin/sh: smbclient: command not found
```

I eagerly await any feedback on this PR. Thanks in advance!

Closes #32 