### PR TITLE
Fix error TS2666

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-import type { Buffer } from "buffer";
-
 declare module "samba-client" {
   interface ISambaClientOptions {
     readonly address: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samba-client",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "wrapper for smbclient",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This fixes error TS2666: "Exports and export assignments are not permitted in module augmentations".

Explicitly importing `type { Buffer } from "buffer"` isn't really necessary, all you need is to have `@types/node` installed.