### PR TITLE
FIx for ENOTDIR error in yarn 2+ or electron

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,11 +71,11 @@ class SambaClient {
   }
 
   async mkdir(remotePath, cwd) {
-    return await this.execute("mkdir", [remotePath], cwd || __dirname);
+    return await this.execute("mkdir", [remotePath], cwd);
   }
 
   async dir(remotePath, cwd) {
-    return await this.execute("dir", [remotePath], cwd || __dirname);
+    return await this.execute("dir", [remotePath], cwd);
   }
 
   async fileExists(remotePath, cwd) {


### PR DESCRIPTION
Removed `__dirname` as this is taking script directory path. directory name is not necessary for this function however in the `execute` function if `cwd` is undefined it will set empty string. 

As an example of this issue is when `list` function is called it does not pass `cwd` which will force it to set `__dirname` path.
And second issue we cannot pass `empty` string which again will set __dirname as default 

when used with `yarn` 2+ with  cache enabled that path will be a zip file.